### PR TITLE
Fixed reference error in ClientSocket.coffee

### DIFF
--- a/src/ClientSocket.coffee
+++ b/src/ClientSocket.coffee
@@ -9,7 +9,7 @@ DEFAULT_WINDOW_SIZE = 1000
 SEND_WINDOW_SIZE_FACTOR = 10
 
 DroppedError = (message) ->
-    Error.captureStackTrace this, TooShortError
+    Error.captureStackTrace this, lumberjack.TooShortError
     @name = 'DroppedError'
     @message = message
 DroppedError.prototype = Object.create(Error.prototype)


### PR DESCRIPTION
`TooShortError`, which is defined in `lumberjack.coffee`, was used as if it were a global variable in `ClientSocket.coffee`, which caused this exception

```
ReferenceError: TooShortError is not defined
     at Error.DroppedError (/home/elssar/apps/log-forwarder/node_modules/lumberjack-protocol/lib/ClientSocket.js:23:35)
     at ClientSocket.writeDataFrame (/home/elssar/apps/log-forwarder/node_modules/lumberjack-protocol/lib/ClientSocket.js:112:21)
     at Client.writeDataFrame (/home/elssar/apps/log-forwarder/node_modules/lumberjack-protocol/lib/Client.js:59:29)
     at /home/elssar/apps/log-forwarder/api/services/LogstashService.js:126:18
     at Array.forEach (native)
     at /home/elssar/apps/log-forwarder/api/services/LogstashService.js:125:19
     at fn (/home/elssar/apps/log-forwarder/node_modules/sails/node_modules/async/lib/async.js:641:34)
     at Immediate._onImmediate (/home/elssar/apps/log-forwarder/node_modules/sails/node_modules/async/lib/async.js:557:34)
     at processImmediate [as _immediateCallback] (timers.js:358:17)
```
