### PR TITLE
Forward unref call to actual socket

### DIFF
--- a/src/ClientSocket.coffee
+++ b/src/ClientSocket.coffee
@@ -131,4 +131,7 @@ class ClientSocket extends EventEmitter
         @_closed = true
         @_disconnect()
 
+    unref: ->
+        @_socket.unref()
+
 module.exports = ClientSocket


### PR DESCRIPTION
I think the `unref` call [here](https://github.com/benbria/node-lumberjack-protocol/blob/master/src/Client.coffee#L131) is actually calling unref on a `ClientSocket`, meaning we need to forward it to the actual underlying socket there?
